### PR TITLE
Update coding standards dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
 	"type": "project",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wp-coding-standards/wpcs": "^2.2.0",
+		"wp-coding-standards/wpcs": "^2.3.0",
 		"automattic/vipwpcs": "^2.0.0",
-		"squizlabs/php_codesniffer": "^3.3.0",
+		"squizlabs/php_codesniffer": "^3.5.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
 	},
 	"require-dev": {}


### PR DESCRIPTION
This updates two different packages used by our standards:

* WPCS is updated to 2.3.0 (release notes: https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.3.0)
* Squizlabs PHPCS updated to 3.5.x (was 3.3.x – See all logs https://github.com/squizlabs/PHP_CodeSniffer/releases)