### PR TITLE
Disallow long array syntax

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -16,9 +16,12 @@
 	<!-- Use the VIP Go ruleset. -->
 	<rule ref="WordPress-VIP-Go" />
 
-	<!-- 
+	<!--
 	Alley specific customizations.
 	-->
+
+	<!-- We prefer short array syntax. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
 	<!-- Allow for common global prefixes used in Alley code. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">


### PR DESCRIPTION
This pairs with our previous exclusion of `Generic.Arrays.DisallowShortArraySyntax.Found` to enforce short array syntax in our codebases.