### PR TITLE
Update WPVIP standard to v2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"automattic/vipwpcs": "^2.0.0",
+		"automattic/vipwpcs": "^2.1.0",
 		"squizlabs/php_codesniffer": "^3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {}
 }


### PR DESCRIPTION
Changes:

* automattic/vipwpcs: ^.2.1.0 [release notes](https://github.com/Automattic/VIP-Coding-Standards/releases/tag/2.1.0)
* dealerdirect/phpcodesniffer-composer-installer: ^0.7

Closes #4 