### PR TITLE
Allow short ternary syntax

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -11,6 +11,8 @@
 	<rule ref="WordPress">
 		<!-- Allow short array syntax. -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<!-- Allow short ternary expressions -->
+		<exclude name="WordPress.PHP.DisallowShortTernary" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->


### PR DESCRIPTION
This excludes the `WordPress.PHP.DisallowShortTernary` rule from our sniffs.

Fixes #3 