### PR TITLE
Update the ruleset + composer package name

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Alley Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Alley Interactive" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>The Alley Interactive PHP coding standard.</description>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Alley">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Alley Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>The Alley Interactive PHP coding standard.</description>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The previous example will also install a version of PHPCS to your vendor directo
 To use this standard with `phpcs` directly from your command line, use the command:
 
 ```
-vendor/bin/phpcs --standard=Alley-Coding-Standards .
+vendor/bin/phpcs --standard=Alley-Interactive .
 ```
 
 Alternatively, you can set this as a composer script, which will automatically reference the correct version of `phpcs` and the dependent standards.
 
 ```
 "scripts": {
-    "phpcs" : "phpcs --standard=Alley-Coding-Standards ."
+    "phpcs" : "phpcs --standard=Alley-Interactive ."
 }
 ```
 
@@ -57,7 +57,7 @@ You can create a custom ruleset for your project that extends or customizes thes
 	<description>Example project ruleset</description>
 
     <!-- Include Alley Rules -->
-    <rule ref="Alley-Coding-Standards" />
+    <rule ref="Alley-Interactive" />
 
     <!-- Project customizations go here -->
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ To use this standard in a project, declare it as a dependency.
 composer require alleyinteractive/alley-coding-standards
 ```
 
+This will install the latest compatible version of PHPCS, WPCS, and VIPCS to your vendor directory in order to run sniffs locally.
+
+You can also manually add this to your project's composer.json file as part of the `require` property:
+
 ```
-"require-dev": {
-    "alleyinteractive/alley-coding-standards": "0.2.0"
+"require": {
+    "alleyinteractive/alley-coding-standards": "^0.2.0"
 }
 ```
-
-The previous example will also install a version of PHPCS to your vendor directory in order to run sniffs locally.
 
 ## Using PHPCS
 
@@ -40,7 +42,7 @@ Then use the following command:
 composer run phpcs
 ```
 
-You can also pass arguments to the componser phpcs script, following a `--` operator like this:
+You can also pass arguments to the composer phpcs script, following a `--` operator like this:
 
 ```
 composer run phpcs -- --report=summary
@@ -68,6 +70,7 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
 ## 0.2.0
 
+- Sniff name changed to Alley-Interactive.
 - Composer package renamed to `alleyinteractive/alley-coding-standards`.
 
 ## 0.1.0

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "alleyinteractive/alley-coding-standards",
 	"description": "PHPCS sniffs for Alley Interactive",
-	"type" : "phpcodesniffer-standard",
+	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"squizlabs/php_codesniffer": "^3.5.0",

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
 	"type" : "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wp-coding-standards/wpcs": "^2.3.0",
-		"automattic/vipwpcs": "^2.1.0",
 		"squizlabs/php_codesniffer": "^3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"wp-coding-standards/wpcs": "^2.3.0",
+		"automattic/vipwpcs": "^2.1.0"
 	},
 	"require-dev": {}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "alley/alley-coding-standards",
 	"description": "PHPCS sniffs for Alley Interactive",
-	"type": "project",
+	"type" : "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"wp-coding-standards/wpcs": "^2.3.0",


### PR DESCRIPTION
This updates the name of our standard ruleset to `Alley-Interactive` — dropping the redundant "Coding-Standards" from the name and conforming to the pattern used by other rulesets, e.g., WordPress, WordPress-Core, WordPress-VIP-Go, etc. 

Related, this updates the name property's namespace in our composer.json file to `alleyinteractive/alley-coding-standards` in preparation for publishing to Packagist. This incorporates @srtfisher's work in #7 so that these breaking changes can be merged at one time.

Docs are updated accordingly