### PR TITLE
Test hotfix for alphabatizing installed paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,15 @@
 	"description": "PHPCS sniffs for Alley Interactive",
 	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "git@github.com:kevinfodness/phpcodesniffer-composer-installer.git"
+		}
+	],
 	"require": {
 		"squizlabs/php_codesniffer": "^3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"dealerdirect/phpcodesniffer-composer-installer": "dev-hotfix/alphabetize-installed-paths",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"automattic/vipwpcs": "^2.1.0",
 		"phpcompatibility/phpcompatibility-wp": "*"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "git@github.com:kevinfodness/phpcodesniffer-composer-installer.git"
+			"url": "https://github.com/kevinfodness/phpcodesniffer-composer-installer"
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,9 @@
 	"description": "PHPCS sniffs for Alley Interactive",
 	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/kevinfodness/phpcodesniffer-composer-installer"
-		}
-	],
 	"require": {
 		"squizlabs/php_codesniffer": "^3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "dev-hotfix/alphabetize-installed-paths",
+		"dealerdirect/phpcodesniffer-composer-installer": "dev-master",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"automattic/vipwpcs": "^2.1.0",
 		"phpcompatibility/phpcompatibility-wp": "*"


### PR DESCRIPTION
**DO NOT MERGE:** This branch is for experimentation only and should not be merged.

---

This installs the dealerdirect PHPCS installer fork from @kevinfodness in order to test that https://github.com/Dealerdirect/phpcodesniffer-composer-installer/issues/125 is working as expected.

To use this branch on a project, you'll need to add the following to your composer.json file:

```json
  "minimum-stability": "dev",
```