### PR TITLE
Ignore template parts in plugins and themes

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -32,7 +32,7 @@
 		</properties>
 
 		<!-- In practice, partials should be loaded outside of the global namespace with get_template_part(). -->
-		<exclude-pattern>themes(/vip)?/[^/]+/template-parts/</exclude-pattern>
+		<exclude-pattern>(plugins|themes)(/vip)?/[^/]+/template-parts/</exclude-pattern>
 		<exclude-pattern>vendor/</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
The starter plugin also uses template parts (for rendering blocks) but the exclusion for prefixes only applies to themes. This change makes the exclusion also apply to template parts in plugins.