### PR TITLE
Allow 'wp_cache_set' in our company standards

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -64,18 +64,4 @@
 		-->
 		<type>error</type>
 	</rule>
-
-	<!-- Forbidden functions -->
-	<rule ref="Generic.PHP.ForbiddenFunctions">
-		<properties>
-			<property name="forbiddenFunctions" type="array">
-				<!--
-				WordPress.com VIP does not propagate wp_cache_set data across data centers,
-				largely to avoid attempting to propagate large (>50k) data for batcache.
-				-->
-				<element key="wp_cache_add" value="wp_cache_set"/>
-			</property>
-        </properties>
-	</rule>
-
 </ruleset>


### PR DESCRIPTION
WP VIP no longer recommends not using `wp_cache_set()` so we shouldn't discourage it either. In fact, it has advantages over using transients, which is what people tend to use instead, so we want to encourage its use.