### PR TITLE
Include sniffing of .js and .jsx files

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -2,10 +2,10 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Alley Interactive" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>The Alley Interactive PHP coding standard.</description>
 
+	<arg name="extensions" value="php,js,jsx"/>
+	
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*.js</exclude-pattern>
-	<exclude-pattern>*.css</exclude-pattern>
 
 	<!-- Use the WordPress ruleset, with some customizations. -->
 	<rule ref="WordPress">


### PR DESCRIPTION
This removes the exclude pattern of `*.js` files and `*.css` files in favor of explicitly setting the `extensions` arg value. This should allow JS sniffs included in any rulesets we care about to run on JS and JSX files, while keeping `.css` files from being included.