### PR TITLE
Add PHPCompatibilityWP support and configure for PHP 7.3

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -21,8 +21,8 @@
 	<!-- Use the PHPCompatibilityWP rules -->
 	<rule ref="PHPCompatibilityWP" />
 
-	<!-- Check for cross-version support for PHP 7.3 and higher. -->
-	<config name="testVersion" value="7.3-"/>
+	<!-- Check for cross-version support for PHP 7.4 and higher. -->
+	<config name="testVersion" value="7.4-"/>
 
 	<!--
 	Alley specific customizations.

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -18,6 +18,12 @@
 	<!-- Use the VIP Go ruleset. -->
 	<rule ref="WordPress-VIP-Go" />
 
+	<!-- Use the PHPCompatibilityWP rules -->
+	<rul ref="PHPCompatibilityWP" />
+
+	<!-- Check for cross-version support for PHP 7.3 and higher. -->
+	<config name="testVersion" value="7.3-"/>
+
 	<!--
 	Alley specific customizations.
 	-->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -19,7 +19,7 @@
 	<rule ref="WordPress-VIP-Go" />
 
 	<!-- Use the PHPCompatibilityWP rules -->
-	<rul ref="PHPCompatibilityWP" />
+	<rule ref="PHPCompatibilityWP" />
 
 	<!-- Check for cross-version support for PHP 7.3 and higher. -->
 	<config name="testVersion" value="7.3-"/>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ You can create a custom ruleset for your project that extends or customizes thes
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.0
+
+- Add PHPCompatibilityWP sniffs to our rules, configured for PHP 7.4+
 ## 0.3.0
 
 - Add PHPCompatibilityWP standard as a dependency (#9)


### PR DESCRIPTION
Many of our projects are adding `PHPCompatabilityWP` checks manually and we include the rulesets for these as a dependency already. Should we go ahead and add these rules to the main coding standard and configure a default PHP version? Currently, I'm targeting 7.3 in this PR since we still have some projects on older systems.