### PR TITLE
Allow users to lint non php files if desired

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -4,8 +4,9 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*.js</exclude-pattern>
-	<exclude-pattern>*.css</exclude-pattern>
+	
+	<!-- Only lint php files by default -->
+	<arg name="extensions" value="php" />
 
 	<!-- Use the WordPress ruleset, with some customizations. -->
 	<rule ref="WordPress">


### PR DESCRIPTION
Instead of excluding all `*.js` and `*.css` files from being linted, set the `extensions` param to be `php`. This allows users to override the `extensions` argument as needed.