### PR TITLE
Ignore template-parts in any part of the path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /vendor/
 composer.lock
+
+# IDEs
+.idea
+.vscode

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -38,7 +38,7 @@
 		</properties>
 
 		<!-- In practice, partials should be loaded outside of the global namespace with get_template_part(). -->
-		<exclude-pattern>(plugins|themes)(/vip)?/[^/]+/template-parts/</exclude-pattern>
+		<exclude-pattern>template-parts/</exclude-pattern>
 		<exclude-pattern>vendor/</exclude-pattern>
 	</rule>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alley Coding Standards
 
-This is a PHPCS ruleset for [Alley Interactive](https://alley.co). Currently only a proof of concept.
+This is a PHPCS ruleset for [Alley Interactive](https://alley.co).
 
 ## Installation
 
@@ -71,6 +71,8 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 ## 0.4.0
 
 - Add PHPCompatibilityWP sniffs to our rules, configured for PHP 7.4+
+- Make template-parts rule checking more ambiguous to better support scanning standalone plugins and themes
+
 ## 0.3.0
 
 - Add PHPCompatibilityWP standard as a dependency (#9)


### PR DESCRIPTION
Currently, the ruleset assumes it will be scanning against a theme or a plugin in a `wp-content` directory, like `wp-content/themes/wp-starter-theme`, and therefore the `template-parts` path matching logic assumes this structure. This works fine when developing locally in a subfolder in a WordPress install, or when working in a repo that is `wp-content` rooted, but it does not work in CI environments for standalone plugins and themes, which will often not be installed to that path (e.g., Buddy, where a standalone plugin is installed to, for example, `/buddy/wp-starter-plugin`). This change relaxes the matching rule for the `template-parts` folder to allow it anywhere in the path.

Fixes #19 