### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "alleyinteractive/alley-coding-standards",
 	"description": "PHPCS sniffs for Alley Interactive",
 	"type": "phpcodesniffer-standard",
+	"keywords": [ "phpcs", "static analysis" ],
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"squizlabs/php_codesniffer": "^3.5.0",


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

The "phpcs" keyword is to match other coding-standards packages.