### PR TITLE
Upgrade automattic/vipwpcs to 2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ You can create a custom ruleset for your project that extends or customizes thes
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+### 0.5.0
+
+- Upgrading to `automattic/vipwpcs` v2.3.3 and `dealerdirect/phpcodesniffer-composer-installer` v0.7.2.
+
 ### 0.4.0
 
 - Add PHPCompatibilityWP sniffs to our rules, configured for PHP 8.0+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can create a custom ruleset for your project that extends or customizes thes
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
-### 0.5.0
+### 0.4.1
 
 - Upgrading to `automattic/vipwpcs` v2.3.3 and `dealerdirect/phpcodesniffer-composer-installer` v0.7.2.
 

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,16 @@
 	"keywords": [ "phpcs", "static analysis" ],
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/vipwpcs": "^2.3.3",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"squizlabs/php_codesniffer": "^3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-		"wp-coding-standards/wpcs": "^2.3.0",
-		"automattic/vipwpcs": "^2.2.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.0"
+		"wp-coding-standards/wpcs": "^2.3.0"
 	},
-	"require-dev": {}
+	"require-dev": {},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	}
 }


### PR DESCRIPTION
Upgrading all dependencies including `automattic/vipwpcs` to v2.3.3 with a small breaking change in their changelog.

~Will require manual testing before releasing.~ Has been tested on a few repositories with no issues.