### PR TITLE
Ignore deprecation error in WPCS until 3.0 is ready to be used

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -25,6 +25,12 @@
 	<config name="testVersion" value="8.0-"/>
 
 	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
+	<!--
 	Alley specific customizations.
 	-->
 

--- a/README.md
+++ b/README.md
@@ -64,52 +64,13 @@ You can create a custom ruleset for your project that extends or customizes thes
 </ruleset>
 ```
 
-## Using Alley Coding Standards on PHP 8.1
-
-If you plan on using this ruleset on PHP 8.1, you will need to make some
-modifications to your Composer configuration. For some context, the current
-version of this ruleset requires `wp-coding-standards/wpcs` 2.3. This package is
-not compatible with PHP 8.1 and runs into some issues when being used. Until
-`wp-coding-standards/wpcs` 3.0 is released we can use a forked version of the
-package that is compatible with PHP 8.1.
-
-### 1. Add the Repository
-
-Add the Composer repository to your project's `composer.json` file:
-
-```json
-{
-    "repositories": {
-        "wpcs": {
-            "type": "vcs",
-            "url": "https://github.com/alleyinteractive/WordPress-Coding-Standards"
-        }
-    }
-}
-```
-
-### 2. Switch to the Forked Version
-
-Add the following to your `composer.json` file `autoload-dev` section:
-
-```json
-{
-    "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^1.0",
-        "wp-coding-standards/wpcs": "dev-php-8-1 as 2.3.x-dev"
-    },
-}
-```
-
-### 3. Run `composer update`
-
-If you run into any problems, please open an issue. After
-`wp-coding-standards/wpcs` 3.0 is released we will remove the above fork from
-our projects and rely on the official release.
-
 ## Change Log
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
+
+### 1.0.1
+
+- Ignore deprecation errors in WPCS to allow it work with PHP 8.0+.
 
 ### 1.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords": [ "phpcs", "static analysis" ],
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/vipwpcs": "^2.3.3",
+		"automattic/vipwpcs": "^2.3.4",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4"
 	},
 	"config": {


### PR DESCRIPTION
Use a fix from https://github.com/WordPress/WordPress-Coding-Standards/issues/2035#issuecomment-1325532520 to allow the coding standards to be used against PHP 8.0+ without requiring any extra Composer repository.

It looks as if https://github.com/Automattic/VIP-Coding-Standards preparing to release a new version soon that will require WPCS 3.0 given the latest changes in their `develop` branch. In the meantime, we can allow our projects to use the Alley Coding Standards against PHP 8.0+ without needing a Composer workaround. Upgrading to PHP 8.1 will be as simple as `composer update` to make PHPCS happy.