### PR TITLE
[Version 2]: Upgrading to WPCS/VIPCS 3.0

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -11,6 +11,8 @@
 	<rule ref="WordPress">
 		<!-- Allow short array syntax. -->
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
+		<!-- Allow any name to be used as a function paramater name. -->
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -11,8 +11,12 @@
 	<rule ref="WordPress">
 		<!-- Allow short array syntax. -->
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
+		<!-- Allow short ternary expressions -->
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
 		<!-- Allow any name to be used as a function paramater name. -->
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
+		<!-- Allow post-increment/decrement vs disallowing it. -->
+		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -10,9 +10,7 @@
 	<!-- Use the WordPress ruleset, with some customizations. -->
 	<rule ref="WordPress">
 		<!-- Allow short array syntax. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-		<!-- Allow short ternary expressions -->
-		<exclude name="WordPress.PHP.DisallowShortTernary" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->
@@ -23,12 +21,6 @@
 
 	<!-- Check for cross-version support for PHP 8.0 and higher. -->
 	<config name="testVersion" value="8.0-"/>
-
-	<!--
-	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
-	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
-	-->
-	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 
 	<!--
 	Alley specific customizations.

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -77,4 +77,9 @@
 		-->
 		<type>error</type>
 	</rule>
+
+	<!-- Ignore an issue with singleton classes instance methods being flagged. -->
+	<rule ref="Universal.CodeAnalysis.ConstructorDestructorReturn.ReturnValueFound">
+		<exclude-pattern>(class|trait)-(instance|singleton).php</exclude-pattern>
+	</rule>
 </ruleset>

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -19,6 +19,7 @@
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
 		<!-- Allow checking any capability. -->
 		<exclude name="WordPress.WP.Capabilities.Undetermined" />
+		<exclude name="WordPress.WP.Capabilities.Unknown" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -17,6 +17,8 @@
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
 		<!-- Allow post-increment/decrement vs disallowing it. -->
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
+		<!-- Allow checking any capability. -->
+		<exclude name="WordPress.WP.Capabilities.Undetermined" />
 	</rule>
 
 	<!-- Use the VIP Go ruleset. -->

--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ You can create a custom ruleset for your project that extends or customizes thes
 </ruleset>
 ```
 
-## Upgrading to 2.0
-
-This version upgrades the library to WordPress Coding Standards and VIP Coding
-Standards 3.0. This includes several breaking changes and renames of various
-sniffs, including:
-
-- ...
-
 ## Change Log
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
@@ -79,7 +71,7 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 ### 2.0.0
 
 - **Breaking Change:** Upgraded to `automattic/vipwpcs` and
-  `wp-coding-standards/wpcs` to 3.0. See [Upgrading to 2.0](#upgrading-to-20])
+  `wp-coding-standards/wpcs` to 3.0. See [Upgrading to 2.0](https://github.com/alleyinteractive/alley-coding-standards/wiki/Upgrading-to-2.0)
   for more details.
 
 ### 1.0.1

--- a/README.md
+++ b/README.md
@@ -64,9 +64,23 @@ You can create a custom ruleset for your project that extends or customizes thes
 </ruleset>
 ```
 
+## Upgrading to 2.0
+
+This version upgrades the library to WordPress Coding Standards and VIP Coding
+Standards 3.0. This includes several breaking changes and renames of various
+sniffs, including:
+
+- ...
+
 ## Change Log
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
+
+### 2.0.0
+
+- **Breaking Change:** Upgraded to `automattic/vipwpcs` and
+  `wp-coding-standards/wpcs` to 3.0. See [Upgrading to 2.0](#upgrading-to-20])
+  for more details.
 
 ### 1.0.1
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords": [ "phpcs", "static analysis" ],
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/vipwpcs": "^2.3.4",
+		"automattic/vipwpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4"
 	},
 	"config": {


### PR DESCRIPTION
Upgrading to the latest version of the WordPress/VIP Coding Standards with a README on breaking changes.

Resolves #31

- [x] Upgrade the dependency.
- [x] Create an upgrade guide to allow for easy upgrading on our projects.