### PR TITLE
Proposal: Add support for function arguments to be passed in the same line as the function

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -20,6 +20,8 @@
     <!-- Allow checking any capability. -->
     <exclude name="WordPress.WP.Capabilities.Undetermined" />
     <exclude name="WordPress.WP.Capabilities.Unknown" />
+    <!-- Disable the PEAR-style function call signature. -->
+    <exclude name="PEAR.Functions.FunctionCallSignature" />
   </rule>
 
   <!-- Use the VIP Go ruleset. -->
@@ -95,4 +97,17 @@
   <rule ref="WordPress.Files.FileName.InvalidClassFileName">
     <exclude-pattern>tests/*Test.php</exclude-pattern>
   </rule>
+
+  <!--
+  Replace PEAR.Functions.FunctionCallSignature with a sniff that supports
+  arguments on the same line as the function call while still requiring
+  spaces after the opening parenthesis and before the closing parenthesis.
+  -->
+  <rule ref="PSR2.Methods.FunctionCallSignature">
+		<properties>
+			<property name="requiredSpacesAfterOpen" value="1" />
+			<property name="requiredSpacesBeforeClose" value="1" />
+			<property name="allowMultipleArguments" value="true" />
+		</properties>
+	</rule>
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 ### Unreleased
 
 - Allow PSR-4 style `ClassName.php` file names to support our migration to PSR-4 for test files.
+- Remove the `PEAR.Functions.FunctionCallSignature` sniff from the ruleset and
+  replace it with `PSR2.Methods.FunctionCallSignature`. This change is to allow
+  for multi-line function calls to be formatted in a more readable way without having to insert a new line before the first argument.
 
 ### 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ form of a passing test in `tests/fixtures/pass` and a failing one in
 `tests/fixtures/fail`. You can run the tests with `composer phpunit`. If you
 want to run PHPCS against the test fixtures, you can run
 `composer phpcs:fixtures` to ensure that what is passing/failing matches your
-expectations.
+expectations. For failing fixtures in `tests/fixtures/fail`, we recommend
+keeping the files smaller and focused on the specific sniff being tested.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also pass arguments to the composer phpcs script, following a `--` opera
 composer run phpcs -- --report=summary
 ```
 
-### Extending the ruleset
+### Extending the Ruleset
 
 You can create a custom ruleset for your project that extends or customizes
 these rules by creating your own `phpcs.xml` file in your project, which
@@ -67,6 +67,16 @@ references these rules, like this:
   <!-- Project customizations go here -->
 </ruleset>
 ```
+
+## Testing
+
+When contributing to this project, modifications to the ruleset should have a
+corresponding test in the `tests` directory. For the most part, this takes the
+form of a passing test in `tests/fixtures/pass` and a failing one in
+`tests/fixtures/fail`. You can run the tests with `composer phpunit`. If you
+want to run PHPCS against the test fixtures, you can run
+`composer phpcs:fixtures` to ensure that what is passing/failing matches your
+expectations.
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   },
   "scripts": {
     "phpcbf": "phpcbf --standard=Alley-Interactive tests/*Test.php",
-    "phpcs": "phpcs --standard=Alley-Interactive tests/*Test.php -vsn",
-    "phpcs:fixtures": "phpcs --standard=Alley-Interactive tests/fixtures",
+    "phpcs": "phpcs --standard=Alley-Interactive tests/*Test.php -sn",
+    "phpcs:fixtures": "phpcs -sn --standard=Alley-Interactive tests/fixtures",
     "phpunit": "phpunit",
     "test": [
       "@phpcs",

--- a/tests/PhpcsHelper.php
+++ b/tests/PhpcsHelper.php
@@ -26,7 +26,7 @@ trait PhpcsHelper {
 
 		$base_path = dirname( __DIR__ );
 		$shell     = sprintf(
-			'%s %s %s --standard=%s --no-cache --report=json',
+			'%s %s "%s" --standard=%s --no-cache --report=json',
 			PHP_BINARY,
 			"{$base_path}/vendor/bin/phpcs",
 			$file,

--- a/tests/fixtures/fail/functions-empty-arguments.php
+++ b/tests/fixtures/fail/functions-empty-arguments.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Functions test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+ai_method_call( );

--- a/tests/fixtures/fail/functions-space-arguments.php
+++ b/tests/fixtures/fail/functions-space-arguments.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Functions test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+// Ensure that there is a space between the opening parenthesis and the function arguments.
+// Supports PSR2.Methods.FunctionCallSignature
+ai_method_call([
+	'foo' => 'bar',
+]);

--- a/tests/fixtures/pass/functions.php
+++ b/tests/fixtures/pass/functions.php
@@ -17,6 +17,14 @@ ai_method_call( [
 	'foo' => 'bar',
 ] );
 
+ai_method_call( [
+	'foo'     => 'bar',
+	'another' => 'test',
+	'depth'   => [
+		'one' => 'two',
+	],
+] );
+
 ai_method_call(
 	[
 		'foo' => 'bar',

--- a/tests/fixtures/pass/functions.php
+++ b/tests/fixtures/pass/functions.php
@@ -10,3 +10,18 @@ $ai_function = function () {
 };
 
 echo esc_html( $ai_function() );
+
+// Allow function arguments on the same line as the function call.
+// Supports PSR2.Methods.FunctionCallSignature.
+ai_method_call( [
+	'foo' => 'bar',
+] );
+
+ai_method_call(
+	[
+		'foo' => 'bar',
+	]
+);
+
+ai_method_call( [ 'foo' => 'bar' ] );
+ai_method_call();


### PR DESCRIPTION
Allows multi-line function calls to support passing arguments on the same line as the function name. For example, this is now valid code:

```php
ai_method_call( [
	'foo' => 'bar',
] );
```

Previously had to only write this as (still supported though):

```php
ai_method_call(
	[
		'foo' => 'bar',
	]
);
```

Disables the `PEAR.Functions.FunctionCallSignature` sniff entirely and replaces it with `PSR2.Methods.FunctionCallSignature`.