### PR TITLE
Issue-49: Remove whitespace in PHP `strict_types` declaration

### DIFF
--- a/Alley-Interactive/Sniffs/PHP/DisallowShortEchoTagSniff.php
+++ b/Alley-Interactive/Sniffs/PHP/DisallowShortEchoTagSniff.php
@@ -7,7 +7,6 @@
 
 namespace Alley\Sniffs\PHP;
 
-use PHP_CodeSniffer\Files\File;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -37,8 +36,7 @@ class DisallowShortEchoTagSniff extends Sniff {
 	 *
 	 * Any detected short echo tags will be flagged as an error.
 	 *
-	 * @param File $file The file being scanned.
-	 * @param int  $stack_ptr The position of the current token in the stack passed in $tokens.
+	 * @param int $stack_ptr The position of the current token in the stack.
 	 */
 	public function process_token( $stackPtr ) {
 		$error = 'Short echo tag (<?=) is not allowed. Use full PHP tags with echo instead.';

--- a/Alley-Interactive/Sniffs/PHP/StrictTypeDeclarationSpacingSniff.php
+++ b/Alley-Interactive/Sniffs/PHP/StrictTypeDeclarationSpacingSniff.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * StrictTypeDeclarationSpacingSniff class file
+ *
+ * @package Alley\CodingStandards
+ */
+
+namespace Alley\Sniffs\PHP;
+
+use WordPressCS\WordPress\Sniff;
+
+class StrictTypeDeclarationSpacingSniff extends Sniff {
+	/**
+	 * Returns tokens to listen for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register() {
+		return [ T_DECLARE ];
+	}
+
+	/**
+	 * Processes this sniff when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function process_token( $stackPtr ) {
+		$tokens = $this->phpcsFile->getTokens();
+
+		// Find strict_types declaration.
+		$strictTypePtr = $this->phpcsFile->findNext(T_STRING, $stackPtr + 1, null, false, 'strict_types');
+		if ( $strictTypePtr === false ) {
+			return;
+		}
+
+		// Check for the opening parenthesis.
+		$openParenPtr = $this->phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
+		if ($openParenPtr !== false) {
+
+			// Check for space after OPENING parenthesis.
+			$nextTokenPtr = $openParenPtr + 1;
+			if ($tokens[$nextTokenPtr]['code'] === T_WHITESPACE) {
+				$error = 'No space allowed after opening parenthesis in strict_types declaration';
+				$fix   = $this->phpcsFile->addFixableError($error, $nextTokenPtr, 'SpaceAfterOpenParenthesis');
+				if ($fix) {
+					$this->phpcsFile->fixer->replaceToken($nextTokenPtr, '');
+				}
+			}
+
+			// Check for space before ENDing parenthesis.
+			$endParenPtr = $this->phpcsFile->findNext(T_CLOSE_PARENTHESIS, $nextTokenPtr + 1);
+			if ($endParenPtr !== false && $tokens[$endParenPtr - 1]['code'] === T_WHITESPACE) {
+				$error = 'No space allowed before closing parenthesis in strict_types declaration';
+				$fix   = $this->phpcsFile->addFixableError($error, $endParenPtr - 1, 'SpaceBeforeCloseParenthesis');
+				if ($fix) {
+					$this->phpcsFile->fixer->replaceToken($endParenPtr - 1, '');
+				}
+			}
+		}
+	}
+}

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -13,7 +13,7 @@
     <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
     <!-- Allow short ternary expressions -->
     <exclude name="Universal.Operators.DisallowShortTernary.Found" />
-    <!-- Allow any name to be used as a function paramater name. -->
+    <!-- Allow any name to be used as a function parameter name. -->
     <exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
     <!-- Allow post-increment/decrement vs disallowing it. -->
     <exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
@@ -33,9 +33,7 @@
   <!-- Check for cross-version support for PHP 8.1 and higher. -->
   <config name="testVersion" value="8.1-"/>
 
-  <!--
-  Alley specific customizations.
-  -->
+  <!-- Alley specific customizations. -->
 
   <!-- We prefer short array syntax. -->
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
@@ -49,7 +47,7 @@
       <property name="prefixes" type="array" value="wp_starter_theme,ai_,_ai" />
     </properties>
 
-    <!-- In practice, partials should be loaded outside of the global namespace with get_template_part(). -->
+    <!-- In practice, partials should be loaded outside the global namespace with get_template_part(). -->
     <exclude-pattern>template-parts/</exclude-pattern>
     <exclude-pattern>vendor/</exclude-pattern>
   </rule>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+### 2.3.0
+
+- Added sniff to warn about whitespaces in `declare( strict_types = 1 );` declarations and require
+  them to be removed `declare(strict_types=1);`:
+  `Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeCloseParenthesis`.
+
 ### 2.2.0
 
 - Added sniff to detect the usage of short PHP echo tags (`<?=`) and require the

--- a/tests/PhpcsHelper.php
+++ b/tests/PhpcsHelper.php
@@ -108,5 +108,4 @@ trait PhpcsHelper {
 			$this->fail( 'Test did not fail as expected' );
 		}
 	}
-
 }

--- a/tests/fixtures/fail/strict-type-declaration-2.php
+++ b/tests/fixtures/fail/strict-type-declaration-2.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare( strict_types=1 );

--- a/tests/fixtures/fail/strict-type-declaration-3.php
+++ b/tests/fixtures/fail/strict-type-declaration-3.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare( strict_types=1);

--- a/tests/fixtures/fail/strict-type-declaration-4.php
+++ b/tests/fixtures/fail/strict-type-declaration-4.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare(strict_types=1 );

--- a/tests/fixtures/fail/strict-type-declaration-5.php
+++ b/tests/fixtures/fail/strict-type-declaration-5.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare(strict_types=0);

--- a/tests/fixtures/fail/strict-type-declaration.php
+++ b/tests/fixtures/fail/strict-type-declaration.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare( strict_types = 1 );

--- a/tests/fixtures/pass/strict-type-declaration.php
+++ b/tests/fixtures/pass/strict-type-declaration.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Strict type test file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+declare(strict_types=1);


### PR DESCRIPTION
### Summary

Fixes #49

This pull request addresses the removal of whitespace in PHP `strict_types` declarations and introduces a new PHP CodeSniffer sniff to enforce this standard. The goal is to standardize the usage of strict typing declarations to the format:

```php
declare(strict_types=1);
```

instead of:

```php
declare( strict_types = 1 );
```

This change aligns with best practices and the proposed standards for `declare` statements in modern PHP. Additionally, this PR introduces the `StrictTypeDeclarationSpacingSniff` class to automatically detect and enforce this formatting in the codebase.

### Related Issues

- https://github.com/WordPress/WordPress-Coding-Standards/issues/2422
- [Proposed standards for declare statement](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) under the heading "Declare statements / strict typing"

### Changes

1. **New PHP CodeSniffer Sniff**:
   - Added the `StrictTypeDeclarationSpacingSniff` class under the `Alley\Sniffs\PHP` namespace to enforce formatting rules for `strict_types` declarations.
   - Introduced tests for this sniff with both passing and failing test cases.

2. **Improved Code Consistency**:
   - Removed unnecessary imports (e.g., `use PHP_CodeSniffer\Files\File;`).
   - Updated PHPDoc blocks to reflect changes in method signatures.

3. **Test Fixtures**:
   - Added several test files in `tests/fixtures/fail/` and `tests/fixtures/pass/` directories to verify the behavior of the new sniff.
   - Test cases include various scenarios for `strict_types` declarations with and without proper formatting.

4. **Minor Cleanups**:
   - Fixed typographical errors in comments.
   - Removed a blank line at the end of `tests/PhpcsHelper.php` for code consistency.

### Testing Instructions

1. Review the updated code to ensure all instances of `declare( strict_types = 1 );` have been replaced with `declare(strict_types=1);`.
2. Verify that the `StrictTypeDeclarationSpacingSniff` correctly identifies and enforces the formatting rules.
3. Run the PHP linter and coding standards tools to ensure compliance.
4. Execute the test suite to confirm the changes do not introduce any regressions.

### Additional Notes

PHP does not enforce a specific format for the `strict_types` declaration, but this standardization helps maintain consistency across the codebase and aligns with community best practices. The introduction of the `StrictTypeDeclarationSpacingSniff` ensures ongoing adherence to these standards.