### PR TITLE
Issue-48: Disable Yoda Conditions

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -43,6 +43,11 @@
     <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
   </rule>
 
+  <!-- Disallow Yoda conditions. -->
+  <rule ref="WordPress">
+    <exclude name="WordPress.PHP.YodaConditions.NotYoda.Found" />
+  </rule>
+
   <!-- Allow for common global prefixes used in Alley code. -->
   <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
     <properties>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+### 2.3.0
+
+- Disabled Yoda conditions.
+
 ### 2.2.0
 
 - Added sniff to detect the usage of short PHP echo tags (`<?=`) and require the

--- a/tests/fixtures/pass/non-yoda.php
+++ b/tests/fixtures/pass/non-yoda.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Yoda test file.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+$yoda_post_type = 'post';
+
+if ( $yoda_post_type == 'post' ) {
+	$category = get_the_category();
+}
+
+if ( 'post' == $yoda_post_type ) {
+	$category = get_the_category();
+}


### PR DESCRIPTION
### Summary

Fixes #48

This pull request proposes disabling the requirement for Yoda conditionals in our codebase. The use of Yoda conditions, while historically helpful, no longer provides sufficient benefits to justify their continued enforcement. This change aligns with the feedback provided in the related issue discussion.

### Motivation

The main motivation for this change is to improve code readability and maintainability. Yoda conditions are inherently "backwards" in their structure, which can make the code harder to understand. With our current enforcements, such as prohibiting assignments in conditionals and requiring strict comparisons, the original benefits of Yoda conditions are no longer relevant.

### Changes Made

- Updated `ruleset.xml` to exclude the `WordPress.PHP.YodaConditions.NotYoda.Found` rule, effectively disabling the enforcement of Yoda conditions.
- Added a new PHP test file, `non-yoda.php`, in the `tests/fixtures/pass` directory to verify the updated rules.
- Updated `CHANGELOG.md` to include a new entry for version `2.3.0` documenting the changes to Yoda condition enforcement.
- Added relevant documentation updates to reflect these changes.

### Testing

- Verified that the updated linting rules no longer flag Yoda conditions.
- Ran the updated ruleset across existing code to ensure compatibility and identify any issues.
- Added a test file to validate the behavior of the updated linting rules.

### Additional Context

For further details, please refer to the following resources:
- [WordPress.org Docs](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#yoda-conditions)
- [Declined proposal in core to remove Yoda conditions](https://make.wordpress.org/core/2022/06/14/upcoming-disallow-assignments-in-conditions-and-remove-the-yoda-condition-requirement-for-php/)

Feedback from the discussion: 
> "Given our other enforcements, like 'no assignments in a conditional' and requiring strict comparisons, worth it yodas are not. They are by definition 'backwards', therefore making code harder to read. While at one point their benefits outweighed that cost, that's no longer the case, and I agree with disabling the linting rules." - @mboynes

Please review and share any additional thoughts or concerns.