### PR TITLE
Issue-46: Improve tests to match the error reported for the stub files with the expected error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+### 2.3.3
+- Changed: Improves tests to ensure tests expected to fail only fail for expected reasons.
+
 ### 2.3.2
 
 - Lock `wp-coding-standards/wpcs` to 3.1.0 to avoid issues with the latest version.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,19 @@ references these rules, like this:
 When contributing to this project, modifications to the ruleset should have a
 corresponding test in the `tests` directory. For the most part, this takes the
 form of a passing test in `tests/fixtures/pass` and a failing one in
-`tests/fixtures/fail`. You can run the tests with `composer phpunit`. If you
+`tests/fixtures/fail`.
+
+You can run the tests with `composer phpunit`. If you
 want to run PHPCS against the test fixtures, you can run
 `composer phpcs:fixtures` to ensure that what is passing/failing matches your
-expectations. For failing fixtures in `tests/fixtures/fail`, we recommend
+expectations.
+
+### Special Considerations for failure expectations
+For failing fixtures in `tests/fixtures/fail`, we recommend
 keeping the files smaller and focused on the specific sniff being tested.
+A corresponding file should be created in `tests/fixtures/fail/expectations`
+referencing the expected source of the failures for that test file. Name the file
+the same as you do the fixture (e.g. `tests/fixtures/fail/foo.php` and `tests/fixtures/fail/expectations/foo.php`).
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "phpcbf": "phpcbf --standard=Alley-Interactive tests/*Test.php",
     "phpcs": "phpcs --standard=Alley-Interactive tests/*Test.php -sn",
     "phpcs:fixtures": "phpcs -sn --standard=Alley-Interactive tests/fixtures",
+    "phpcs:expectations": "phpcs -sn --standard=Alley-Interactive tests/fixtures/fail/expectations",
     "phpunit": "phpunit",
     "test": [
       "@phpcs",

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -32,10 +32,22 @@ class FixtureTest extends TestCase {
 	 * Test that fixtures fail.
 	 *
 	 * @param string $file The file to test.
+	 * @param string $expectation The expectations file for this test.
 	 */
 	#[DataProvider( 'failing_fixture_data_provider' )]
-	public function test_failing_fixtures( string $file ): void {
-		$this->process_phpcs_output( $this->run_phpcs( $file ), expect_to_fail: true );
+	public function test_failing_fixtures( string $file, ?string $expectation = null ): void {
+
+		$expectations = [];
+
+		if ( ! empty( $expectation ) && file_exists( $expectation ) ) {
+			$expectations = include $expectation;
+		}
+
+		$this->process_phpcs_output(
+			$this->run_phpcs( $file ),
+			ignored_errors: $expectations,
+			expect_to_fail: true
+		);
 	}
 
 	/**
@@ -53,7 +65,19 @@ class FixtureTest extends TestCase {
 	 * @return array<array<string|array<string>>>
 	 */
 	public static function failing_fixture_data_provider(): array {
-		return self::get_files_in_directory( __DIR__ . '/fixtures/fail' );
+		$data         = self::get_files_in_directory( __DIR__ . '/fixtures/fail' );
+		$expectations = self::get_files_in_directory( __DIR__ . '/fixtures/fail/expectations' );
+
+		foreach ( $data as $key => $data_set ) {
+			if ( ! isset( $expectations[ $key ] ) ) {
+				$data[ $key ][] = null;
+				continue;
+			}
+
+			$data[ $key ][] = $expectations[ $key ][0];
+		}
+
+		return $data;
 	}
 
 	/**
@@ -76,6 +100,10 @@ class FixtureTest extends TestCase {
 		$data = [];
 
 		foreach ( $files as $file ) {
+			if ( is_dir( $file ) ) {
+				continue;
+			}
+
 			$data[ basename( $file ) ] = [ $file ];
 		}
 

--- a/tests/PhpcsHelper.php
+++ b/tests/PhpcsHelper.php
@@ -76,13 +76,6 @@ trait PhpcsHelper {
 			);
 
 			if ( ! empty( $unexpected_messages ) ) {
-				// Bail if we expect the test to fail and there are errors.
-				if ( $expect_to_fail ) {
-					$this->assertTrue( true );
-
-					return;
-				}
-
 				$this->fail(
 					sprintf(
 						'Unexpected errors found in %s: %s',
@@ -104,8 +97,12 @@ trait PhpcsHelper {
 			),
 		);
 
-		if ( $expect_to_fail ) {
+		if ( $expect_to_fail && empty( $errors ) ) {
 			$this->fail( 'Test did not fail as expected' );
+		} else if ( $expect_to_fail && ! empty( $errors ) ) {
+			$this->assertNotEmpty( $errors );
+		} else {
+			$this->assertEmpty( $errors );
 		}
 	}
 }

--- a/tests/fixtures/fail/expectations/array.php
+++ b/tests/fixtures/fail/expectations/array.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Array expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Generic.Arrays.DisallowLongArraySyntax.Found',
+];

--- a/tests/fixtures/fail/expectations/functions-empty-arguments.php
+++ b/tests/fixtures/fail/expectations/functions-empty-arguments.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Function Empty Arguments expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket',
+	'PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket',
+];

--- a/tests/fixtures/fail/expectations/functions-space-arguments.php
+++ b/tests/fixtures/fail/expectations/functions-space-arguments.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Functions expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket',
+	'PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket',
+];

--- a/tests/fixtures/fail/expectations/one-object-structure.php
+++ b/tests/fixtures/fail/expectations/one-object-structure.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Function Empty Arguments expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Generic.Files.OneObjectStructurePerFile.MultipleFound',
+];

--- a/tests/fixtures/fail/expectations/shorthand-tag.php
+++ b/tests/fixtures/fail/expectations/shorthand-tag.php
@@ -5,7 +5,6 @@
  * @package Alley\WP\Coding_Standards
  */
 
-
 /**
  * Return the array of expected failures that this test file should generate.
  */

--- a/tests/fixtures/fail/expectations/shorthand-tag.php
+++ b/tests/fixtures/fail/expectations/shorthand-tag.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Shorthand Tag expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.DisallowShortEchoTag.Found',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-2.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-2.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterOpenParenthesis',
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeCloseParenthesis',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-3.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-3.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterOpenParenthesis',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-4.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-4.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeCloseParenthesis',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-5.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-5.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'PHPCompatibility.ControlStructures.NewExecutionDirectives.strict_typesInvalidValueFound',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-6.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-6.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeEquals',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-7.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-7.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterEquals',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration-8.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration-8.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeEquals',
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterEquals',
+];

--- a/tests/fixtures/fail/expectations/strict-type-declaration.php
+++ b/tests/fixtures/fail/expectations/strict-type-declaration.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Strict Type Declarations expectations file.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+/**
+ * Return the array of expected failures that this test file should generate.
+ */
+return [
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterOpenParenthesis',
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeEquals',
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceAfterEquals',
+	'Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeCloseParenthesis',
+];

--- a/tests/fixtures/fail/functions-space-arguments.php
+++ b/tests/fixtures/fail/functions-space-arguments.php
@@ -6,7 +6,7 @@
  */
 
 // Ensure that there is a space between the opening parenthesis and the function arguments.
-// Supports PSR2.Methods.FunctionCallSignature
+// Supports PSR2.Methods.FunctionCallSignature.
 ai_method_call([
 	'foo' => 'bar',
 ]);

--- a/tests/fixtures/fail/shorthand-tag.php
+++ b/tests/fixtures/fail/shorthand-tag.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * Shorthand Tag Functions file.
+ *
+ * @package Alley\WP\CodingStandards
+ */
+
+?>
+
 <div
 	class="example <?= esc_attr( $class ); ?>"
 	data-action="<?= esc_attr( $action ); ?>"


### PR DESCRIPTION
### Summary

Fixes #46

This PR enhances the reliability and accuracy of failing test fixtures by ensuring that the errors reported by PHPCS in stub files match the expected errors defined in new "expectations" files. It introduces per-test error expectations, so stub files now fail only for the intended, documented reasons, not for unrelated issues.

### Key Changes

- **Test Enhancements:**  
  - The test suite now supports expectations for failing fixtures by allowing each test to reference an associated expectations file.
  - The testing logic has been updated so that failures are only accepted if they match the expected error(s) listed in the corresponding expectations file.
  - Improved logic in `process_phpcs_output` ensures that unexpected errors cause test failures, increasing test reliability.

- **Expectations Directory:**  
  - Created `tests/fixtures/fail/expectations/` directory containing new PHP files that specify the expected code standard violations for each failing fixture.
  - Added expectation files for a variety of test cases, including array syntax, function arguments, short echo tags, and strict type declarations.

- **Composer Script:**  
  - Added a new Composer script `phpcs:expectations` to easily run PHPCS checks specifically against the expectations directory and surface only relevant errors.

- **Documentation Updates:**  
  - Expanded the README with clearer instructions for contributing and running tests, including a new section detailing the use of expectations files.
  - Clarified the process for maintaining focused, concise failing fixtures.

### Motivation

Previously, stub files intended to fail could do so for reasons unrelated to the specific test, making it difficult to ensure that the right coding standard was being enforced. This update aligns test failures with explicit expectations, inspired by practices in [Automattic/VIP-Coding-Standards](https://github.com/Automattic/VIP-Coding-Standards/blob/develop/tests/RulesetTest.php), and directly addresses the concerns raised in #46.

### Testing

- [x] Verify that each failing stub file is checked against its expectation file and only fails for the correct, intended reason.
- [x] Confirm that the new Composer script (`composer phpcs:expectations`) runs successfully and surfaces only expected errors.
- [x] Ensure that documentation clearly explains how to contribute new failing fixture tests with expectations.

### Additional Notes

- This update introduces a more maintainable and robust workflow for testing coding standard violations.
- Expectation files make it easier to pinpoint and fix unintended issues in the test suite.
- The approach strengthens the reliability of the coding standards enforcement process.