### PR TITLE
Upgrade the project to wpcs 3.3 / relax standards for test files

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -41,6 +41,8 @@
     <exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed" />
     <!-- Allow meta calls without having to pass single = true. -->
     <exclude name="WordPress.WP.GetMetaSingle.Missing" />
+    <!-- Remove long condition comment requirement. -->
+    <exclude name="Squiz.Commenting.LongConditionClosingComment" />
   </rule>
 
   <!-- For context: https://github.com/Automattic/VIP-Coding-Standards/issues/442 -->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -119,6 +119,11 @@
     <exclude-pattern>tests/*</exclude-pattern>
   </rule>
 
+  <!-- Remove DB requirements from test files -->
+  <rule ref="WordPress.DB">
+    <exclude-pattern>tests/*</exclude-pattern>
+  </rule>
+
   <!--
   Replace PEAR.Functions.FunctionCallSignature with a sniff that supports
   arguments on the same line as the function call while still requiring

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -69,6 +69,11 @@
     <exclude-pattern>vendor/</exclude-pattern>
   </rule>
 
+  <!-- Allow unescaped output in test files. -->
+  <rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+    <exclude-pattern>tests/*</exclude-pattern>
+  </rule>
+
   <!-- Keep common boilerplate code from triggering an error. -->
   <rule ref="Squiz.Commenting.FileComment.SpacingAfterComment">
     <!--
@@ -102,6 +107,16 @@
   <!-- Allow PSR-4 file format for test files -->
   <rule ref="WordPress.Files.FileName.InvalidClassFileName">
     <exclude-pattern>tests/*Test.php</exclude-pattern>
+  </rule>
+
+  <!-- Allow non-prefixed classes in test files -->
+  <rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+    <exclude-pattern>tests/*</exclude-pattern>
+  </rule>
+
+  <!-- Remove commenting requirements from test files -->
+  <rule ref="Squiz.Commenting">
+    <exclude-pattern>tests/*</exclude-pattern>
   </rule>
 
   <!--

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -59,13 +59,12 @@
   <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
     <properties>
       <property name="prefixes" type="array">
-        <element value="_ai"/>
-        <element value="ai_"/>
-        <element value="wp_starter_theme"/>
+        <element value="alley_"/>
       </property>
     </properties>
 
     <!-- In practice, partials should be loaded outside the global namespace with get_template_part(). -->
+    <exclude-pattern>blocks/</exclude-pattern>
     <exclude-pattern>template-parts/</exclude-pattern>
     <exclude-pattern>vendor/</exclude-pattern>
   </rule>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,54 @@
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
-### 2.3.3
-- Changed: Improves tests to ensure tests expected to fail only fail for expected reasons.
+## 2.4.0
 
-### 2.3.2
+**🚨Breaking change:** Upgraded to `wp-coding-standards/wpcs` 3.3+ which changes the prefix length
+from 3 to 4. Previously, a prefix like `ai_` was allowed. This is now invalid and must be changed
+to `alley_` or a similar 4 character prefix.
+
+To continue using a 3 character prefix, you can lock `wp-coding-standards/wpcs` to version 3.2.0
+in your project's `composer.json` file like this:
+
+```json
+{
+	"require-dev": {
+		"wp-coding-standards/wpcs": "3.2.0"
+	}
+}
+```
+
+### Changes
+
+- Drops the package's requirement on a specific version of `wp-coding-standards/wpcs`. Will now
+  install the latest compatible version used by `automattic/vipwpcs`.
+- Improves tests to ensure tests expected to fail only fail for expected reasons.
+- Drops `phpcompatibility/phpcompatibility-wp` as a dependency.
+
+## 2.3.2
 
 - Lock `wp-coding-standards/wpcs` to 3.1.0 to avoid issues with the latest version.
 - Remove `WordPress.WP.GetMetaSingle.Missing` sniff that will be introduced in WPCS 3.2.0.
 
-### 2.3.1
+## 2.3.1
 
 - Updated `StrictTypeDeclarationSpacingSniff` to remove additional space.
 - Address deprecated warnings and notices.
 
-### 2.3.0
+## 2.3.0
 
 - Added sniff to warn about whitespaces in `declare( strict_types = 1 );` declarations and require
   them to be removed `declare(strict_types=1);`:
   `Alley.PHP.StrictTypeDeclarationSpacing.SpaceBeforeCloseParenthesis`.
 - Disabled Yoda conditions.
 
-### 2.2.0
+## 2.2.0
 
 - Added sniff to detect the usage of short PHP echo tags (`<?=`) and require the
   use of the full PHP echo tags (`<?php echo`):
   `Alley.PHP.DisallowShortEchoTag.Found`.
 
-### 2.1.0
+## 2.1.0
 
 - Allow PSR-4 style `ClassName.php` file names to support our migration to PSR-4 for test files.
 - Remove the `PEAR.Functions.FunctionCallSignature` sniff from the ruleset and
@@ -36,51 +57,51 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
   for multi-line function calls to be formatted in a more readable way without having to insert a new line before the first argument.
 - Allow camelCase'd DOMDocument/DOMElement/etc. property names to not be flagged by `WordPress.NamingConventions.ValidVariableName`.
 
-### 2.0.2
+## 2.0.2
 
 - Fix issue with files with `js`/`css` in the path being ignored.
 - Bumping to PHP 8.1.
 
-### 2.0.1
+## 2.0.1
 
 - Update "Prefer array syntax" rule to 3.0.
 
-### 2.0.0
+## 2.0.0
 
 - **Breaking Change:** Upgraded to `automattic/vipwpcs` and
   `wp-coding-standards/wpcs` to 3.0. See [Upgrading to 2.0](https://github.com/alleyinteractive/alley-coding-standards/wiki/Upgrading-to-2.0)
   for more details.
 
-### 1.0.1
+## 1.0.1
 
 - Ignore deprecation errors in WPCS to allow it work with PHP 8.0+.
 
-### 1.0.0
+## 1.0.0
 
 - No changes, tagging a stable release of Alley Coding Standards.
 
-### 0.4.1
+## 0.4.1
 
 - Upgrading to `automattic/vipwpcs` v2.3.3 and `dealerdirect/phpcodesniffer-composer-installer` v0.7.2.
 
-### 0.4.0
+## 0.4.0
 
 - Add PHPCompatibilityWP sniffs to our rules, configured for PHP 8.0+
 - Make template-parts rule checking more ambiguous to better support scanning standalone plugins and themes
 - Added `static analysis` keyword to Composer to promote package to be installed with `--dev`.
 
-### 0.3.0
+## 0.3.0
 
 - Add PHPCompatibilityWP standard as a dependency (#9)
 - Exclude plugin template parts from WordPress.NamingConventions.PrefixAllGlobals sniff (#11)
 - Remove 'wp_cache_set' from forbidden functions (#12)
 
-### 0.2.0
+## 0.2.0
 
 - Sniff name changed to Alley-Interactive.
 - Composer package renamed to `alleyinteractive/alley-coding-standards`.
-- Allow short ternary syntax (#6)
+- Allow short ternary syntax.
 
-### 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ in your project's `composer.json` file like this:
   any variable naming conventions in block files.
 - Improves tests to ensure tests expected to fail only fail for expected reasons.
 - Drops `phpcompatibility/phpcompatibility-wp` as a dependency.
+- Relax rules for test files.
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ in your project's `composer.json` file like this:
 
 - Drops the package's requirement on a specific version of `wp-coding-standards/wpcs`. Will now
   install the latest compatible version used by `automattic/vipwpcs`.
+- Drop `WordPress.NamingConventions.PrefixAllGlobals` sniff from `blocks/` directory to allow for
+  any variable naming conventions in block files.
 - Improves tests to ensure tests expected to fail only fail for expected reasons.
 - Drops `phpcompatibility/phpcompatibility-wp` as a dependency.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-++# Alley Coding Standards
+# Alley Coding Standards
 
 [![Example of a badge pointing to the readme standard spec](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alley Coding Standards
+++# Alley Coding Standards
 
 [![Example of a badge pointing to the readme standard spec](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "automattic/vipwpcs": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^12"
+    "phpunit/phpunit": "^12",
+    "symfony/finder": "^7.4"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "static analysis"
   ],
   "require": {
-    "automattic/vipwpcs": "^3.0",
-    "wp-coding-standards/wpcs": ">=3.1.0 <3.2.0"
+    "automattic/vipwpcs": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^12"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
   backupGlobals="false"
   colors="true"
   cacheDirectory=".phpunit.result.cache"
@@ -9,6 +9,7 @@
   <testsuites>
     <testsuite name="tests">
       <directory suffix="Test.php">tests</directory>
+      <exclude>tests/fixtures/*</exclude>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -83,8 +83,8 @@ class FixtureTest extends TestCase {
 	/**
 	 * Returns an array of fixtures that should fail.
 	 *
-	 * @param string $directory The directory to get files from.
-	 * @param int    $depth The depth to search.
+	 * @param string      $directory The directory to get files from.
+	 * @param string|null $depth The depth to search.
 	 * @return array<string>
 	 */
 	protected static function get_files_in_directory( string $directory, ?string $depth = null ): array {
@@ -98,7 +98,7 @@ class FixtureTest extends TestCase {
 			->name( '*.php' );
 
 		if ( null !== $depth ) {
-			$finder->depth($depth);
+			$finder->depth( $depth );
 		}
 
 		$data = [];

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -11,6 +11,7 @@ namespace Alley\WP\Coding_Standards\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Fixture Test
@@ -65,8 +66,8 @@ class FixtureTest extends TestCase {
 	 * @return array<array<string|array<string>>>
 	 */
 	public static function failing_fixture_data_provider(): array {
-		$data         = self::get_files_in_directory( __DIR__ . '/fixtures/fail' );
-		$expectations = self::get_files_in_directory( __DIR__ . '/fixtures/fail/expectations' );
+		$data         = self::get_files_in_directory( __DIR__ . '/fixtures/fail', '== 0' );
+		$expectations = self::get_files_in_directory( __DIR__ . '/fixtures/fail/expectations', '== 0' );
 
 		foreach ( $data as $key => $data_set ) {
 			if ( ! isset( $expectations[ $key ] ) ) {
@@ -84,27 +85,27 @@ class FixtureTest extends TestCase {
 	 * Returns an array of fixtures that should fail.
 	 *
 	 * @param string $directory The directory to get files from.
+	 * @param int    $depth The depth to search.
 	 * @return array<string>
 	 */
-	protected static function get_files_in_directory( string $directory ): array {
+	protected static function get_files_in_directory( string $directory, ?string $depth = null ): array {
 		if ( ! is_dir( $directory ) ) {
 			return [];
 		}
 
-		$files = glob( $directory . '/*' );
+		$finder = Finder::create()
+			->files()
+			->in( $directory )
+			->name( '*.php' );
 
-		if ( ! is_array( $files ) ) {
-			return [];
+		if ( null !== $depth ) {
+			$finder->depth($depth);
 		}
 
 		$data = [];
 
-		foreach ( $files as $file ) {
-			if ( is_dir( $file ) ) {
-				continue;
-			}
-
-			$data[ basename( $file ) ] = [ $file ];
+		foreach ( $finder as $file ) {
+			$data[ $file->getBasename() ] = [ $file->getRealPath() ];
 		}
 
 		return $data;

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -37,7 +37,6 @@ class FixtureTest extends TestCase {
 	 */
 	#[DataProvider( 'failing_fixture_data_provider' )]
 	public function test_failing_fixtures( string $file, ?string $expectation = null ): void {
-
 		$expectations = [];
 
 		if ( ! empty( $expectation ) && file_exists( $expectation ) ) {

--- a/tests/fixtures/fail/array.php
+++ b/tests/fixtures/fail/array.php
@@ -5,4 +5,4 @@
  * @package Alley\WP\Coding_Standards
  */
 
-$ai_another = array( 5, 6, 7, 8 );
+$alley_another = array( 5, 6, 7, 8 );

--- a/tests/fixtures/fail/one-object-structure.php
+++ b/tests/fixtures/fail/one-object-structure.php
@@ -8,7 +8,7 @@
 /**
  * Example class.
  */
-class AI_Example {
+class Alley_Example {
 	/**
 	 * Example property.
 	 *
@@ -29,7 +29,7 @@ class AI_Example {
 /**
  * Example class.
  */
-class AI_Another_Example {
+class Alley_Another_Example {
 	/**
 	 * Example property.
 	 *

--- a/tests/fixtures/pass/array.php
+++ b/tests/fixtures/pass/array.php
@@ -5,4 +5,4 @@
  * @package Alley\WP\Coding_Standards
  */
 
-$ai_example = [ 1, 2, 3 ];
+$alley_example = [ 1, 2, 3 ];

--- a/tests/fixtures/pass/blocks/block-prefix-globals.php
+++ b/tests/fixtures/pass/blocks/block-prefix-globals.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Test for WordPress.NamingConventions.PrefixAllGlobals in block files.
+ *
+ * @global array $attributes Block attributes passed to the render callback.
+ * @global string $content Block content from InnerBlocks passed to the render callback.
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+$display = $attributes['display'] ?: 'author';

--- a/tests/fixtures/pass/dom.php
+++ b/tests/fixtures/pass/dom.php
@@ -8,21 +8,21 @@
  * @package Alley\WP\Coding_Standards
  */
 
-$ai_document = new DOMDocument();
+$alley_document = new DOMDocument();
 
 // Ensure that DOMDocument properties are allowed.
-$ai_document->preserveWhiteSpace = false;
-$ai_document->formatOutput       = true;
+$alley_document->preserveWhiteSpace = false;
+$alley_document->formatOutput       = true;
 
-$ai_document->loadHTML(
+$alley_document->loadHTML(
 	file_get_contents( 'https://www.alley.com' ) // phpcs:ignore
 );
 
 // Interact with the DOM document.
-$ai_element = $ai_document->getElementById( 'element-id' );
+$alley_element = $alley_document->getElementById( 'element-id' );
 
 // Ensure that DOMElement properties are allowed.
-$ai_element->textContent = 'Hello, world!';
-$ai_element->className   = 'element-class';
+$alley_element->textContent = 'Hello, world!';
+$alley_element->className   = 'element-class';
 
-$ai_tag = $ai_element->tagName;
+$alley_tag = $alley_element->tagName;

--- a/tests/fixtures/pass/functions.php
+++ b/tests/fixtures/pass/functions.php
@@ -5,11 +5,11 @@
  * @package Alley\WP\Coding_Standards
  */
 
-$ai_function = function () {
+$alley_function = function () {
 	return 'Hello, World!';
 };
 
-echo esc_html( $ai_function() );
+echo esc_html( $alley_function() );
 
 // Allow function arguments on the same line as the function call.
 // Supports PSR2.Methods.FunctionCallSignature.

--- a/tests/fixtures/pass/ternary.php
+++ b/tests/fixtures/pass/ternary.php
@@ -7,5 +7,5 @@
  * @package Alley\WP\Coding_Standards
  */
 
-$ai_initial = true;
-$ai_result  = $ai_initial ?: 'value';
+$alley_initial = true;
+$alley_result  = $alley_initial ?: 'value';

--- a/tests/fixtures/pass/tests/ExampleTest.php
+++ b/tests/fixtures/pass/tests/ExampleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Example test file
+ *
+ * @package Alley\WP\Coding_Standards
+ */
+
+class ExampleTest {
+	public function test_example(): void {
+		echo $unknown_variable;
+		echo get_blog_info( 'name' );
+	}
+}

--- a/tests/fixtures/pass/tests/ExampleTest.php
+++ b/tests/fixtures/pass/tests/ExampleTest.php
@@ -10,5 +10,33 @@ class ExampleTest {
 	public function test_example(): void {
 		echo $unknown_variable;
 		echo get_blog_info( 'name' );
+
+		// Perform a meta query.
+		$query = new WP_Query(
+			[
+				'post_type'  => 'post',
+				'meta_query' => [
+					[
+						'key'     => 'example_key',
+						'value'   => 'example_value',
+						'compare' => '=',
+					],
+				],
+			]
+		);
+
+		// Perform a tax query.
+		$query = new WP_Query(
+			[
+				'post_type' => 'post',
+				'tax_query' => [
+					[
+						'taxonomy' => 'category',
+						'field'    => 'slug',
+						'terms'    => 'example-category',
+					],
+				],
+			]
+		);
 	}
 }


### PR DESCRIPTION
With no way to modify the sniff (length is a const), we will upgrade to WPCS 3.3.

Resolves #44. Resolves #59.