### PR TITLE
Ignore Squiz.Commenting.PostStatementComment.AnnotationFound sniff

### DIFF
--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -43,6 +43,8 @@
     <exclude name="WordPress.WP.GetMetaSingle.Missing" />
     <!-- Remove long condition comment requirement. -->
     <exclude name="Squiz.Commenting.LongConditionClosingComment" />
+    <!-- Remove sniff that is flagging phpstan-ignore-line comments. -->
+    <exclude name="Squiz.Commenting.PostStatementComment.AnnotationFound" />
   </rule>
 
   <!-- For context: https://github.com/Automattic/VIP-Coding-Standards/issues/442 -->

--- a/Alley-Interactive/ruleset.xml
+++ b/Alley-Interactive/ruleset.xml
@@ -44,7 +44,7 @@
     <!-- Remove long condition comment requirement. -->
     <exclude name="Squiz.Commenting.LongConditionClosingComment" />
     <!-- Remove sniff that is flagging phpstan-ignore-line comments. -->
-    <exclude name="Squiz.Commenting.PostStatementComment.AnnotationFound" />
+    <exclude name="Squiz.Commenting.PostStatementComment" />
   </rule>
 
   <!-- For context: https://github.com/Automattic/VIP-Coding-Standards/issues/442 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.1
+
+### Changed
+
+- Remove `Squiz.Commenting.PostStatementComment.AnnotationFound` sniff.
+
 ## 2.4.0
 
 **🚨Breaking change:** Upgraded to `wp-coding-standards/wpcs` 3.3+ which changes the prefix length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
-- Remove `Squiz.Commenting.PostStatementComment.AnnotationFound` sniff.
+- Remove `Squiz.Commenting.PostStatementComment` sniff.
 
 ## 2.4.0
 


### PR DESCRIPTION
This sniff recently introduced in wpcs caused previously OK lines with `// @phpcs-ignore-line the.rule` to fail.